### PR TITLE
ntp: update 4.2.8p4 to 4.2.8p6

### DIFF
--- a/meta-networking/recipes-support/ntp/ntp_4.2.8p6.bb
+++ b/meta-networking/recipes-support/ntp/ntp_4.2.8p6.bb
@@ -23,8 +23,8 @@ SRC_URI = "http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/ntp-${PV}.tar.g
            file://ntpd.list \
 "
 
-SRC_URI[md5sum] = "6af96862b09324a8ef965ca76b759c8b"
-SRC_URI[sha256sum] = "0d6961572548d2c4af96f58f763e22ac620f5afef717384ddc317a0e365cfdb9"
+SRC_URI[md5sum] = "60049f51e9c8305afe30eb22b711c5c6"
+SRC_URI[sha256sum] = "583d0e1c573ace30a9c6afbea0fc52cae9c8c916dbc15c026e485a0dda4ba048"
 
 inherit autotools update-rc.d useradd systemd pkgconfig
 


### PR DESCRIPTION
4.2.8p5 fixed following medium-severity vulnerability:
- Bug 2956 / CVE-2015-5300
  
  and fixes a lot of bugs
  
  Bug #2829, #2887, #2932, #2934, #2944, #2952, #2954, #2957, #2958, #2962,
      #2965, #2967, #2969, #2971

4.2.8p5 fixed following low- and medium-severity vulnerabilities:
- Bug 2948 / CVE-2015-8158
- Bug 2945 / CVE-2015-8138
- Bug 2942 / CVE-2015-7979
- Bug 2940 / CVE-2015-7978
- Bug 2939 / CVE-2015-7977
- Bug 2938 / CVE-2015-7976
- Bug 2937 / CVE-2015-7975
- Bug 2936 / CVE-2015-7974
- Bug 2935 / CVE-2015-7973

For details check:
  http://support.ntp.org/bin/view/Main/SecurityNotice#January_2016_NTP_4_2_8p6_Securit

Signed-off-by: Jens Rehsack sno@netbsd.org
